### PR TITLE
Add a message when require_action_allowed! raises SecurityTransgression

### DIFF
--- a/lib/openstax/utilities/access_policy.rb
+++ b/lib/openstax/utilities/access_policy.rb
@@ -24,7 +24,8 @@ module OpenStax
       end
 
       def self.require_action_allowed!(action, requestor, resource)
-        raise SecurityTransgression unless action_allowed?(action, requestor, resource)
+        msg = "\"#{requestor.inspect}\" is not allowed to perform \"#{action}\" on \"#{resource.inspect}\""
+        raise(SecurityTransgression, msg) unless action_allowed?(action, requestor, resource)
       end
 
       def self.action_allowed?(action, requestor, resource)


### PR DESCRIPTION
It now outputs something like this in the console:

SecurityTransgression ("#&lt;OpenStax::Api::ApiUser:0x0000000f1d9638 @doorkeeper_token=nil, @non_doorkeeper_user_proc=#<Proc:0x0000000f1d9660@/home/karen/.rvm/gems/ruby-2.1.3@tutor/gems/openstax_api-5.4.5/app/controllers/openstax/api/v1/api_controller.rb:36 (lambda)>>"
is not allowed to perform "roster" on
"#&lt;Entity::Course id: 1, created_at: "2015-07-23 22:01:08", updated_at: "2015-07-23 22:01:08">")

Close #13