### PR TITLE
Status page should now work even if delayed_job is not being used

### DIFF
--- a/app/controllers/openstax/utilities/status_controller.rb
+++ b/app/controllers/openstax/utilities/status_controller.rb
@@ -12,7 +12,8 @@ class OpenStax::Utilities::StatusController < ActionController::Base
     @statuses = if @environment_name == 'development'
       [ [ 'local', 1, 1, :ok ] ]
     else
-      queues = Delayed::Worker.queue_attributes.keys.map(&:to_s) - [ 'migration' ]
+      queues = Module.const_defined?(:Delayed) && Delayed.const_defined?(:Worker) ?
+        Delayed::Worker.queue_attributes.keys.map(&:to_s) - [ 'migration' ] : []
       asgs = [ 'migration', 'web', 'cron', 'background' ] + queues.map do |queue|
         "background-#{queue}"
       end

--- a/lib/openstax/utilities/version.rb
+++ b/lib/openstax/utilities/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Utilities
-    VERSION = '4.5.0'
+    VERSION = '4.5.1'
   end
 end


### PR DESCRIPTION
Just set queues to be empty if DJ is not installed