### PR TITLE
Support status page for sites without a separate FE

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   tests:
     timeout-minutes: 10
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/app/controllers/openstax/utilities/status_controller.rb
+++ b/app/controllers/openstax/utilities/status_controller.rb
@@ -7,7 +7,7 @@ class OpenStax::Utilities::StatusController < ActionController::Base
 
   def index
     @application_name = OSU::SITE_NAME.humanize
-    @environment_name = Rails.application.secrets.environment_name
+    @environment_name = OpenStax::Utilities.configuration.environment_name
 
     @statuses = if @environment_name == 'development'
       [ [ 'local', 1, 1, :ok ] ]

--- a/app/views/layouts/openstax/utilities/status.html.erb
+++ b/app/views/layouts/openstax/utilities/status.html.erb
@@ -10,6 +10,8 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
     <%= csrf_meta_tags %>
+
+    <style>body { background: none; }</style>
   </head>
 
   <body id="status" class="status">

--- a/app/views/openstax/utilities/status/index.html.erb
+++ b/app/views/openstax/utilities/status/index.html.erb
@@ -12,25 +12,25 @@
     offline: '🔌',
     sleeping: '💤'
   }
-
-  backend = @application_name == 'Tutor' ? 'tutor-server' : @application_name.downcase
 %>
 
 <h3>Versions</h3>
 
 <ul>
   <li>
-    Backend (<%= backend %>): <%=
+    Backend (<%= OpenStax::Utilities.configuration.backend %>): <%=
       OpenStax::Utilities.configuration.release_version || 'not deployed'
     %>
   </li>
   <% unless OpenStax::Utilities.configuration.assets_url.blank? %>
   <li>
-    Frontend (tutor-js): <%= OpenStax::Utilities::Assets.manifest.version || 'not deployed' %>
+    Frontend (<%= OpenStax::Utilities.configuration.frontend %>): <%=
+      OpenStax::Utilities::Assets.manifest.version || 'not deployed'
+    %>
   </li>
   <% end %>
   <li>
-    Deployment (tutor-deployment): <%=
+    Deployment (<%= OpenStax::Utilities.configuration.deployment %>): <%=
       OpenStax::Utilities.configuration.deployment_version || 'not deployed'
     %>
   </li>

--- a/app/views/openstax/utilities/status/index.html.erb
+++ b/app/views/openstax/utilities/status/index.html.erb
@@ -20,14 +20,18 @@
 
 <ul>
   <li>
-    Backend (<%= backend %>): <%= Rails.application.secrets.release_version || 'not deployed' %>
+    Backend (<%= backend %>): <%=
+      OpenStax::Utilities.configuration.release_version || 'not deployed'
+    %>
   </li>
+  <% unless OpenStax::Utilities.configuration.assets_url.blank? %>
   <li>
     Frontend (tutor-js): <%= OpenStax::Utilities::Assets.manifest.version || 'not deployed' %>
   </li>
+  <% end %>
   <li>
     Deployment (tutor-deployment): <%=
-      Rails.application.secrets.deployment_version || 'not deployed'
+      OpenStax::Utilities.configuration.deployment_version || 'not deployed'
     %>
   </li>
 </ul>

--- a/lib/openstax/utilities/assets.rb
+++ b/lib/openstax/utilities/assets.rb
@@ -4,7 +4,7 @@ require_relative 'assets/manifest'
 module OpenStax::Utilities
   module Assets
     def self.url
-      url = Rails.application.secrets.assets_url
+      url = OpenStax::Utilities.configuration.assets_url
       url.ends_with?('/') ? url : "#{url}/"
     end
 

--- a/lib/openstax/utilities/assets/manifest.rb
+++ b/lib/openstax/utilities/assets/manifest.rb
@@ -10,7 +10,9 @@ module OpenStax::Utilities
       def initialize
         @assets = HashWithIndifferentAccess.new
 
-        url = OpenStax::Utilities::Assets.url_for('assets.json')
+        url = OpenStax::Utilities::Assets.url_for(
+          OpenStax::Utilities.configuration.assets_manifest_filename
+        )
 
         begin
           response = self.class.client.get url

--- a/lib/openstax/utilities/version.rb
+++ b/lib/openstax/utilities/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Utilities
-    VERSION = '4.5.2'
+    VERSION = '5.0.0'
   end
 end

--- a/lib/openstax_utilities.rb
+++ b/lib/openstax_utilities.rb
@@ -23,7 +23,6 @@ require "openstax/utilities/assets"
 
 module OpenStax
   module Utilities
-
     # ASSET_FILES = %w(openstax_utilities.css openstax_utilities.js)
 
     # ActiveSupport.on_load(:before_initialize) do
@@ -31,7 +30,6 @@ module OpenStax
     # end
 
     class << self
-
       ###########################################################################
       #
       # Configuration machinery.
@@ -58,17 +56,22 @@ module OpenStax
         attr_accessor :standard_datetime_format
         attr_accessor :standard_time_format
         attr_accessor :status_authenticate
+        attr_accessor :environment_name
+        attr_accessor :release_version
+        attr_accessor :deployment_version
+        attr_accessor :assets_url
+        attr_accessor :assets_manifest_filename
 
         def initialize
           @standard_date_format = "%b %d, %Y"
           @standard_datetime_format = "%b %d, %Y %l:%M %p %Z"
           @standard_time_format = "%l:%M %p %Z"
           @status_authenticate = -> { head :forbidden }
+          @environment_name = 'development'
+          @assets_manifest_filename = 'assets.json'
           super
         end
       end
-
     end
-
   end
 end

--- a/lib/openstax_utilities.rb
+++ b/lib/openstax_utilities.rb
@@ -57,10 +57,13 @@ module OpenStax
         attr_accessor :standard_time_format
         attr_accessor :status_authenticate
         attr_accessor :environment_name
+        attr_accessor :backend
         attr_accessor :release_version
-        attr_accessor :deployment_version
+        attr_accessor :frontend
         attr_accessor :assets_url
         attr_accessor :assets_manifest_filename
+        attr_accessor :deployment
+        attr_accessor :deployment_version
 
         def initialize
           @standard_date_format = "%b %d, %Y"

--- a/spec/dummy/config/initializers/openstax_utilities.rb
+++ b/spec/dummy/config/initializers/openstax_utilities.rb
@@ -1,0 +1,3 @@
+OpenStax::Utilities.configure do |config|
+  config.assets_url = Rails.application.secrets.assets_url
+end

--- a/spec/lib/openstax/utilities/assets_spec.rb
+++ b/spec/lib/openstax/utilities/assets_spec.rb
@@ -25,10 +25,11 @@ RSpec.describe OpenStax::Utilities::Assets, vcr: VCR_OPTS do
 
   context 'loading remote manifest' do
     before do
-      @previous_assets_url = Rails.application.secrets.assets_url
-      Rails.application.secrets.assets_url = 'https://tutor-dev.openstax.org/assets'
+      @config = OpenStax::Utilities.configuration
+      @previous_assets_url = @config.assets_url
+      @config.assets_url = 'https://tutor-dev.openstax.org/assets'
     end
-    after  { Rails.application.secrets.assets_url = @previous_assets_url }
+    after  { @config.assets_url = @previous_assets_url }
 
     it 'uses remote json' do
       expect(described_class.manifest).to be_kind_of described_class::Manifest


### PR DESCRIPTION
Also instead of reading secrets directly, let the application configure those values in the initializer